### PR TITLE
Change yas-load-directory to yas/load-directory.

### DIFF
--- a/elixir-yasnippets.el
+++ b/elixir-yasnippets.el
@@ -16,7 +16,7 @@
 (defun elixir-snippets-initialize ()
   (let ((snip-dir (expand-file-name "snippets" elixir-snippets-dir)))
     (add-to-list 'yas-snippet-dirs snip-dir t)
-    (yas-load-directory snip-dir)))
+    (yas/load-directory snip-dir)))
 
 ;;;###autoload
 (eval-after-load 'yasnippet


### PR DESCRIPTION
Fixes "let: Symbol's function definition is void: yas-load-directory"
