### PR TITLE
Updated to new supervisor status.

### DIFF
--- a/snippets/elixir-mode/supervisor
+++ b/snippets/elixir-mode/supervisor
@@ -5,15 +5,16 @@
 defmodule ${1:Module}.Supervisor do
 use Supervisor
 
-def start_link do
-Supervisor.start_link(__MODULE__, :ok)
+def start_link(init_arg) do
+Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
 end
 
 def init(:ok) do
 children = [
-$0
+ {$0, .. }
+
 ]
-supervise(children, strategy: :one_for_one)
+Supervise.init(children, strategy: :one_for_one)
 end
 
 end


### PR DESCRIPTION
Elixir has deprecated this method of supervisor.

See : https://stackoverflow.com/questions/65664160/how-to-update-from-deprecated-supervisor-spec-to-new-supervisor-behaviour for more discussion on this topic.

This new template (I think) meets the new requirement.

Thanks.